### PR TITLE
Fix: Move @gh-netic-robot to default codeowners line

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* @cortexproject/jsonnet-team
-
-* @gh-netic-robot
+* @cortexproject/jsonnet-team @gh-netic-robot


### PR DESCRIPTION
This PR removes the separate `@gh-netic-robot` line and appends it to the existing default `*` line to consolidate ownership.